### PR TITLE
ci(ltreesitter): build ltreesitter with Makefile

### DIFF
--- a/.github/workflows/ltreesitter.yml
+++ b/.github/workflows/ltreesitter.yml
@@ -22,7 +22,6 @@ jobs:
             base-devel
             git
             mingw-w64-x86_64-tree-sitter
-            mingw-w64-x86_64-lua
             mingw-w64-x86_64-gcc
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -30,10 +29,8 @@ jobs:
           repository: 'takase1121/ltreesitter'
           ref: lite-xl-plugin-api
           submodules: true
-      - name: 'Build'
-        run: make ltreesitter.so && mv ltreesitter.so ltreesitter.dll
-        env:
-          CFLAGS: -I./include -Wall -Wextra -Werror -Og -ggdb -std=c99 -fPIC
+      - name: Build
+        run: make ltreesitter.dll
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
I've updated the makefile so now you can build relese DLLs and SOs.