### PR TITLE
ci: use external action to create releases

### DIFF
--- a/.github/workflows/ltreesitter.yml
+++ b/.github/workflows/ltreesitter.yml
@@ -7,15 +7,6 @@ on:
     branches: master
 
 jobs:
-  create-release:
-    name: Make release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - run: gh release delete -y ltreesitter || true; gh release create -p -t 'ltreesitter' ltreesitter
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
-
   ltreesitter-windows:
     name: ltreesitter on Windows
     runs-on: windows-latest
@@ -49,10 +40,13 @@ jobs:
         with:
           path: builds-repo
       - name: Create Release(s)
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
-        shell: powershell
-        working-directory: builds-repo
-        run: gh release upload ltreesitter ../ltreesitter.dll
+        uses: ncipollo/release-action@v1
+        with:
+          name: 'Builds'
+          tag: builds
+          commit: master
+          allowUpdates: true
+          artifacts: ltreesitter.dll
 
   ltreesitter-linux:
     name: ltreesitter on Linux
@@ -73,11 +67,11 @@ jobs:
         with:
           name: ltreesitter-linux
           path: ltreesitter.so
-      - name: Checkout builds repo
-        uses: actions/checkout@v3
-        with:
-          path: builds-repo
       - name: Create Release(s)
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
-        working-directory: builds-repo
-        run: gh release upload ltreesitter ../ltreesitter.so
+        uses: ncipollo/release-action@v1
+        with:
+          name: 'Builds'
+          tag: builds
+          commit: master
+          allowUpdates: true
+          artifacts: ltreesitter.so

--- a/.github/workflows/ltreesitter.yml
+++ b/.github/workflows/ltreesitter.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Create Release(s)
         uses: ncipollo/release-action@v1
         with:
-          name: 'Builds'
-          tag: builds
+          name: 'ltreesitter'
+          tag: ltreesitter
           commit: master
           allowUpdates: true
           artifacts: ltreesitter.dll
@@ -70,8 +70,8 @@ jobs:
       - name: Create Release(s)
         uses: ncipollo/release-action@v1
         with:
-          name: 'Builds'
-          tag: builds
+          name: 'ltreesitter'
+          tag: ltreesitter
           commit: master
           allowUpdates: true
           artifacts: ltreesitter.so

--- a/.github/workflows/ltreesitter.yml
+++ b/.github/workflows/ltreesitter.yml
@@ -49,7 +49,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: 'ltreesitter'
-          tag: ltreesitter
+          tag: ${{ inputs.tag }}
           commit: master
           allowUpdates: true
           artifacts: ltreesitter.dll
@@ -77,7 +77,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: 'ltreesitter'
-          tag: ltreesitter
+          tag: ${{ inputs.tag }}
           commit: master
           allowUpdates: true
           artifacts: ltreesitter.so

--- a/.github/workflows/parsers.yml
+++ b/.github/workflows/parsers.yml
@@ -59,7 +59,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: 'Treesitter Parsers'
-          tag: parsers
+          tag: ${{ inputs.tag }}
           commit: master
           allowUpdates: true
           artifacts: "*.so"
@@ -118,7 +118,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           name: 'Treesitter Parsers'
-          tag: parsers
+          tag: ${{ inputs.tag }}
           commit: master
           allowUpdates: true
           artifacts: "*.dll"

--- a/.github/workflows/parsers.yml
+++ b/.github/workflows/parsers.yml
@@ -4,15 +4,6 @@ on:
   push
 
 jobs:
-  create-release:
-    name: Make release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - run: gh release delete -y parsers || true; gh release create -p -t 'Treesitter Parsers' parsers
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
-  
   linux-parsers:
     name: Compile Linux parsers
     runs-on: ubuntu-latest
@@ -51,17 +42,20 @@ jobs:
             chmod +x ./fake-gyp &&
             ./fake-gyp ${{ steps.split.outputs.parser }} > Makefile &&
             make &&
-            mv ${{ steps.split.outputs.parser }}/parser.dll ${{ steps.split.outputs.parser }}/parser.so"
+            mv ${{ steps.split.outputs.parser }}/parser.dll ${{ steps.split.outputs.parser }}.so"
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.split.outputs.parser }}-linux-x86_64
           path: |
-            ${{ steps.split.outputs.parser }}/parser.so
+            ${{ steps.split.outputs.parser }}.so
       - name: Upload to release
-        run: |
-          mv ${{ steps.split.outputs.parser }}/parser.so ${{ steps.split.outputs.parser }}.so
-          gh release upload parsers ${{ steps.split.outputs.parser }}.so
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
+        uses: ncipollo/release-action@v1
+        with:
+          name: 'Treesitter Parsers'
+          tag: parsers
+          commit: master
+          allowUpdates: true
+          artifacts: "*.so"
 
   windows-parsers:
     name: Compile Windows parsers
@@ -107,14 +101,17 @@ jobs:
         run: |
           ./fake-gyp ${{ steps.split.outputs.parser }} > Makefile
           make
+          mv ${{ steps.split.outputs.parser }}/parser.dll ${{ steps.split.outputs.parser }}.dll
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.split.outputs.parser }}-windows-x86_64
           path: |
-            ${{ steps.split.outputs.parser }}/parser.dll
+            ${{ steps.split.outputs.parser }}.dll
       - name: Upload to release
-        run: |
-          mv ${{ steps.split.outputs.parser }}/parser.dll ${{ steps.split.outputs.parser }}.dll
-          gh release upload parsers ${{ steps.split.outputs.parser }}.dll
-        shell: powershell
-        env: { GITHUB_TOKEN: "${{ github.token }}" }
+        uses: ncipollo/release-action@v1
+        with:
+          name: 'Treesitter Parsers'
+          tag: parsers
+          commit: master
+          allowUpdates: true
+          artifacts: "*.dll"


### PR DESCRIPTION
This avoids the need to create an extra job to create the release.