### PR TITLE
Make tree-sitter-d work

### DIFF
--- a/.github/workflows/parsers.yml
+++ b/.github/workflows/parsers.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: |
           ./setup.sh
-          make -j$(nproc)
+          LDFLAGS=-static-libstdc++ make -j$(nproc)
         env:
           SOEXT: dll
       - uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# tree-sitter directories
+tree-sitter-*/
+
+# fake-gyp results
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tree-sitter-*/
 
 # fake-gyp results
 Makefile
+*.so
+*.dll

--- a/fake-gyp.py
+++ b/fake-gyp.py
@@ -29,7 +29,7 @@ def generate_target_rules(dir, output=[]):
 
     # generate dynamic library rule
     output.append(f"{dir.stem}.$(SOEXT): {' '.join(objs)}")
-    output.append(f"\t{'$(CXX)' if has_cpp else '$(CC)'} -shared -o $@ $(LDFLAGS) {'-static' if has_cpp else ''} $^")
+    output.append(f"\t{'$(CXX)' if has_cpp else '$(CC)'} -shared -o $@ $(LDFLAGS) $^")
     output.append(f"\t$(STRIP) $@")
 
     for src in srcs:

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 
 REPOS="https://github.com/tree-sitter/tree-sitter-c
 https://github.com/tree-sitter/tree-sitter-cpp
-https://github.com/CyberShadow/tree-sitter-d
+https://github.com/takase1121/tree-sitter-d
 https://github.com/the-mikedavis/tree-sitter-diff
 https://github.com/tree-sitter/tree-sitter-go
 https://github.com/camdencheek/tree-sitter-go-mod


### PR DESCRIPTION
I have a PR (https://github.com/CyberShadow/tree-sitter-d/pull/12) pending approval, after this is done we can use the upstream repo again.

Another notable change is that Linux builds no longer has static libstdc++. This is needed on Windows because Windows does not bring such libraries (neither does Lite XL) and having it built in helps with distribution.

On Linux, this configuration will cause symbol conflict when the parser is loaded into memory; and Linux people usually has libstdc++ installed, so should not be too much of a problem.